### PR TITLE
fix: 🐛 cross fetch should be a dependency, not dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "jest": "^27.1.1",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
-    "typescript": "^4.4.2",
-    "cross-fetch": "^3.1.4"
+    "typescript": "^4.4.2"
   },
   "dependencies": {
     "@dfinity/agent": "^0.9.3",
@@ -48,6 +47,7 @@
     "@dfinity/identity": "^0.9.3",
     "@dfinity/principal": "^0.9.3",
     "buffer-crc32": "^0.2.13",
+    "cross-fetch": "^3.1.4",
     "crypto-js": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/dab-js",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "JS adapter for DAB",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
## Why?

Cross-fetch package is not available when documented feature is used (  https://docs.dab.ooo/nft-list/getting-started/#2-fetching-all-nfts-the-user-owns-getallusernfts ) as reported by user in the community discussion ( https://discord.com/channels/837010835423494144/888441185302118400/908167186722488380 )