### PR TITLE
fix: 🐛 prevent double package publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "jest",
     "lint": "eslint --ext ts,js ./src",
     "watch": "tsc --watch",
-    "publish": "npm run build && npm publish"
+    "package:publish": "npm run build && npm publish"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.32.0",


### PR DESCRIPTION
## Why?

Having a `publish` script causes double publish when running `npm publish`, that should not be the case.