### PR TITLE
fix: dip721v2 will now return v2 for tokens when parsed

### DIFF
--- a/src/standard_wrappers/nft_standards/dip_721_v2.ts
+++ b/src/standard_wrappers/nft_standards/dip_721_v2.ts
@@ -36,7 +36,7 @@ const extractMetadataValue = (metadata: any) => {
 };
 
 export default class ERC721 extends NFT {
-  standard = NFTStandard.dip721;
+  standard = NFTStandard.dip721v2;
 
   actor: ActorSubclass<Interface>;
 


### PR DESCRIPTION
this fixes sending/interacting with the tokens via plug