### PR TITLE
Fix: Dip20 Logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/dab-js",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "JS adapter for DAB",
   "main": "dist/index.js",
   "repository": {

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -1,4 +1,7 @@
 import { Principal } from "@dfinity/principal";
+import { TokenMetaData as ExtMetadata } from "./ext";
+import { Metadata as Dip20Metadata } from "./dip_20";
+
 
 export interface Token {
     'logo' : string,
@@ -9,7 +12,24 @@ export interface Token {
     'standard' : string,
     'total_supply' : [] | [bigint],
     'symbol' : string,
-  }
+}
+
+
+
+export type TokenMetadata = ExtMetadata | Dip20Metadata;
+
+export interface FungibleMetadata {
+  fungible: TokenMetadata & {
+    metadata?: Int8Array[];
+  };
+}
+
+export interface NonFungibleMetadata {
+  nonfungible: {
+    metadata: Int8Array[];
+  };
+}
+export type Metadata = FungibleMetadata | NonFungibleMetadata;
 
 export { SendOpts, SendParams, SendResponse, BalanceResponse, BurnParams } from '../standard_wrappers/token_standards/methods'
 export { EventDetail, BurnResult } from './xtc'

--- a/src/standard_wrappers/token_standards/dip20Methods.ts
+++ b/src/standard_wrappers/token_standards/dip20Methods.ts
@@ -3,7 +3,7 @@ import { Principal } from '@dfinity/principal';
 import { ActorSubclass } from '@dfinity/agent';
 
 import Dip20Service from '../../interfaces/dip_20';
-import { Metadata } from '../../interfaces/ext';
+import { Metadata } from '../../interfaces/token'; 
 import {
   BalanceResponse,
   BurnParams,
@@ -25,6 +25,7 @@ const getMetadata = async (
       symbol: metadataResult.symbol,
       decimals: metadataResult.decimals,
       name: metadataResult.name,
+      logo: metadataResult.logo,
     },
   };
 };

--- a/src/standard_wrappers/token_standards/extMethods.ts
+++ b/src/standard_wrappers/token_standards/extMethods.ts
@@ -1,7 +1,8 @@
 import { ActorSubclass, Actor } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 
-import ExtService, { Metadata } from '../../interfaces/ext';
+import ExtService from '../../interfaces/ext';
+import { Metadata } from '../../interfaces/token';
 import { BaseMethodsExtendedActor } from '../../utils/actorFactory';
 import {
   BalanceResponse,

--- a/src/standard_wrappers/token_standards/icpStandardMethods.ts
+++ b/src/standard_wrappers/token_standards/icpStandardMethods.ts
@@ -4,7 +4,7 @@ import { Actor, ActorSubclass } from '@dfinity/agent';
 import fetch from 'cross-fetch';
 
 import LedgerService from '../../interfaces/ledger';
-import { FungibleMetadata, Metadata } from '../../interfaces/ext';
+import { FungibleMetadata, Metadata } from '../../interfaces/token';
 import {
   BalanceResponse,
   BurnParams,
@@ -42,7 +42,7 @@ const send = async (
   const metadata = await getMetadata(actor);
   const { fee = 0.002, decimals = BigInt(8) } = (metadata as FungibleMetadata)?.fungible || {};
   const defaultArgs = {
-    fee: BigInt(fee * (10 ** parseInt(decimals.toString(), 10))),
+    fee: BigInt((fee as number) * (10 ** parseInt(decimals.toString(), 10))),
     memo: BigInt(0),
   };
   const response = await actor._send_dfx({

--- a/src/standard_wrappers/token_standards/methods.ts
+++ b/src/standard_wrappers/token_standards/methods.ts
@@ -1,7 +1,7 @@
 import { ActorSubclass } from '@dfinity/agent';
 import { Principal } from '@dfinity/principal';
 
-import { Metadata } from '../../interfaces/ext';
+import { Metadata } from '../../interfaces/token';
 import { BurnResult } from '../../interfaces/xtc';
 import { BaseMethodsExtendedActor } from '../../utils/actorFactory';
 

--- a/src/standard_wrappers/token_standards/wicpMethods.ts
+++ b/src/standard_wrappers/token_standards/wicpMethods.ts
@@ -3,7 +3,7 @@ import { Principal } from '@dfinity/principal';
 import { ActorSubclass } from '@dfinity/agent';
 
 import WICPService from '../../interfaces/wicp';
-import { Metadata } from '../../interfaces/ext';
+import { Metadata } from '../../interfaces/token';
 import {
   BalanceResponse,
   BurnParams,
@@ -25,6 +25,7 @@ const getMetadata = async (
       symbol: metadataResult.symbol,
       decimals: metadataResult.decimals,
       name: metadataResult.name,
+      logo: metadataResult.logo,
     },
   };
 };

--- a/src/standard_wrappers/token_standards/xtcMethods.ts
+++ b/src/standard_wrappers/token_standards/xtcMethods.ts
@@ -3,7 +3,7 @@ import { Principal } from '@dfinity/principal';
 import { ActorSubclass } from '@dfinity/agent';
 
 import XtcService, { BurnResult } from '../../interfaces/xtc';
-import { Metadata } from '../../interfaces/ext';
+import { Metadata } from '../../interfaces/token';
 import {
   BalanceResponse,
   BurnParams,
@@ -26,6 +26,7 @@ const getMetadata = async (
       symbol: metadataResult.symbol,
       decimals: metadataResult.decimals,
       name: metadataResult.name,
+      logo: metadataResult.logo,
     },
   };
 };


### PR DESCRIPTION
# Summary
- Made `TokenMetadata` and `Metadata` a generic interface and use it in wrappers. 
- Added logo serialization to dip20 tokens.

## Notes
- Metadata formatting in tokens should probably be revised and split between NFT and FT metadata