### PR TITLE
fix(nft_origyn): get correct token id from balance response

### DIFF
--- a/src/standard_wrappers/nft_standards/nft_origyn.ts
+++ b/src/standard_wrappers/nft_standards/nft_origyn.ts
@@ -30,9 +30,7 @@ export default class NFTOrigyn extends NFT<string, string> {
     }
     const tokensData = await Promise.all(
       tokensIndexes.ok.nfts.map(async (item) => {
-        const tokenIndex = item[0]
-        const principal = item[1]
-        const userTokensResult = await this.actor.nft_origyn(tokenIndex);
+        const userTokensResult = await this.actor.nft_origyn(item);
         if ('err' in userTokensResult)
           throw new Error(Object.keys(userTokensResult.err)[0]);
         return {detail: userTokensResult, principal};


### PR DESCRIPTION
The `nfts` from the response of `balance_of_nft_origyn` contains an array of strings, each string is a token id. 

Reference from `..src/interfaces/nft_origyn.ts`:

```
export interface BalanceResponse {
  'nfts' : Array<string>,
  'sales' : Array<EscrowRecord>,
  'stake' : Array<StakeRecord>,
  'multi_canister' : [] | [Array<Principal>],
  'escrow' : Array<EscrowRecord>,
}
```
Changing the `getUserTokens` to reflect this.
