### PR TITLE
fix: 🐛 remove empty matches when verifying dip721 suffix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/dab-js",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0-beta.2",
   "description": "JS adapter for DAB",
   "main": "dist/index.js",
   "repository": {

--- a/src/registries/nfts_registry.ts
+++ b/src/registries/nfts_registry.ts
@@ -123,7 +123,7 @@ const standardNormaliser = ({
     const userStandardNormalised = standard.toUpperCase();
     const systemStandardNormalised = NFTStandard.dip721.toUpperCase();
     const startsWithDip721 = userStandardNormalised.startsWith(systemStandardNormalised);
-    const hasSuffix = userStandardNormalised.split(systemStandardNormalised).filter(v => v).length > 1;
+    const hasSuffix = userStandardNormalised.split(systemStandardNormalised).filter(v => v).length > 0;
 
     return startsWithDip721 && hasSuffix;
   })();

--- a/src/registries/nfts_registry.ts
+++ b/src/registries/nfts_registry.ts
@@ -123,7 +123,7 @@ const standardNormaliser = ({
     const userStandardNormalised = standard.toUpperCase();
     const systemStandardNormalised = NFTStandard.dip721.toUpperCase();
     const startsWithDip721 = userStandardNormalised.startsWith(systemStandardNormalised);
-    const hasSuffix = userStandardNormalised.split(systemStandardNormalised).length > 1;
+    const hasSuffix = userStandardNormalised.split(systemStandardNormalised).filter(v => v).length > 1;
 
     return startsWithDip721 && hasSuffix;
   })();


### PR DESCRIPTION
## Why?

When the term passed is DIP721, the hint message is displayed when not necessary, as it should only show the message when a suffix exists.